### PR TITLE
When downloading the example messages, include the .xml files and not…

### DIFF
--- a/hit-core-api/src/main/java/gov/nist/hit/core/api/DocumentationController.java
+++ b/hit-core-api/src/main/java/gov/nist/hit/core/api/DocumentationController.java
@@ -299,13 +299,13 @@ public class DocumentationController {
     String pattern = null;
     String name = null;
     if (stage == TestingStage.CB) {
-      pattern = "/*Contextbased/**/Message.t*";
+      pattern = "/*Contextbased/**/Message.*";
       name = "ContextbasedExampleMessages";
     } else if (stage == TestingStage.CF) {
-      pattern = "/*Contextfree/**/Message.t*";
+      pattern = "/*Contextfree/**/Message.*";
       name = "ContextfreeExampleMessages";
     } else if (stage == TestingStage.ISOLATED) {
-      pattern = "/*Isolated/**/Message.t*";
+      pattern = "/*Isolated/**/Message.*";
       name = "IsolatedExampleMessages";
     }
     return generateZip(pattern, name);


### PR DESCRIPTION
… only the .txt ones.

As it's using pattern and not regex, Message.(txt|xml) won't work so we use Message.* as there are only xml and txt messages. Maybe in the future we should change to a regex match.
Issue #13