### PR TITLE
Cascading fix for TestStepValidationReport (CascadeType.REMOVE)

### DIFF
--- a/hit-core-domain/src/main/java/gov/nist/hit/core/domain/TestStep.java
+++ b/hit-core-domain/src/main/java/gov/nist/hit/core/domain/TestStep.java
@@ -99,6 +99,10 @@ public class TestStep extends AbstractTestCase implements Serializable {
   @JsonIgnore
   @ManyToOne(optional=true,fetch = FetchType.EAGER)
   protected TestCase testCase;
+  
+  @JsonIgnore
+  @OneToMany(mappedBy = "testStep", cascade = CascadeType.REMOVE,fetch = FetchType.LAZY)
+  protected List<TestStepValidationReport> reports;
 
  
   public TestStep(String name) {


### PR DESCRIPTION
Problem : Integrity violation when deleting TestStep because TestStepValidationReport has foreign key to TestStep

Solution : Adding CascadeType.REMOVE to OneToMany relationship in TestStep side to TestStepValidationReports