### PR TITLE
MySQL related modifications  

### DIFF
--- a/hit-core-api/src/main/resources/app-auth-schema.sql
+++ b/hit-core-api/src/main/resources/app-auth-schema.sql
@@ -12,6 +12,6 @@ create table IF NOT EXISTS users(
       authority varchar(50) not null,
       constraint fk_authorities_users foreign key(username) references users(username));
   
-  create unique index IF NOT EXISTS ix_auth_username on authorities (username,authority);
+--  create unique index IF NOT EXISTS ix_auth_username on authorities (username,authority);
       
       

--- a/hit-core-domain/src/main/java/gov/nist/hit/core/domain/IntegrationProfile.java
+++ b/hit-core-domain/src/main/java/gov/nist/hit/core/domain/IntegrationProfile.java
@@ -62,10 +62,10 @@ public class IntegrationProfile implements Serializable {
 	protected String description;
 
 	@Column(nullable = true)
-	protected String key;
+	protected String key_;
 
 	@Column(nullable = true)
-	protected String type;
+	protected String type_;
 
 	@Column(nullable = true)
 	protected String schemaVersion;
@@ -121,11 +121,11 @@ public class IntegrationProfile implements Serializable {
 	}
 
 	public String getKey() {
-		return key;
+		return key_;
 	}
 
 	public void setKey(String key) {
-		this.key = key;
+		this.key_ = key;
 	}
 
 	public Long getId() {
@@ -137,11 +137,11 @@ public class IntegrationProfile implements Serializable {
 	}
 
 	public String getType() {
-		return type;
+		return type_;
 	}
 
 	public void setType(String type) {
-		this.type = type;
+		this.type_ = type;
 	}
 
 	public String getSchemaVersion() {

--- a/hit-core-domain/src/main/java/gov/nist/hit/core/domain/VocabularyLibrary.java
+++ b/hit-core-domain/src/main/java/gov/nist/hit/core/domain/VocabularyLibrary.java
@@ -3,17 +3,17 @@ package gov.nist.hit.core.domain;
 import java.io.Serializable;
 
 import javax.persistence.Column;
-import javax.persistence.Embeddable;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 @Entity
+@Table(name = "VocabularyLibrary")
 public class VocabularyLibrary implements Serializable {
  
  
@@ -35,7 +35,7 @@ public class VocabularyLibrary implements Serializable {
   protected String description;
   
   @JsonIgnore
-  protected String key;
+  protected String key_;
   
   @JsonIgnore
   @Column(columnDefinition = "LONGTEXT")
@@ -95,11 +95,11 @@ public class VocabularyLibrary implements Serializable {
   }
 
   public String getKey() {
-    return key;
+    return key_;
   }
 
   public void setKey(String key) {
-    this.key = key;
+    this.key_ = key;
   }
   
   


### PR DESCRIPTION
Changed a few attributs with (MySQL) reserved names (key and type) in VocabularyLibrary and IntergrationProfile entities.

Removed index on authorities also for MySQL compatibility.
“Index creation of authorities is only for performance reasons but won’t have much of an impact here.”